### PR TITLE
On entity rename, change parent name stored on children.

### DIFF
--- a/src/Entity/Behavior/BehaviorAnimalInfo.cs
+++ b/src/Entity/Behavior/BehaviorAnimalInfo.cs
@@ -56,9 +56,28 @@ namespace Genelib {
             if (nametag == null || target.OwnedByOther(fromPlayer)) {
                 return;
             }
+            string newName = message.name;
             target.Api.Logger.Audit(fromPlayer.PlayerName + " changed name of " + target.Code + " ID " + target.EntityId + " at " + target.Pos.XYZ.AsBlockPos 
-                + " from " + nametag.DisplayName + " to " + message.name);
-            nametag.SetName(message.name);
+                + " from " + nametag.DisplayName + " to " + newName);
+	    nametag.SetName(newName);
+
+	    // Update stored parent name on all offspring
+            long renamedUID = target.UniqueID();
+            var loadedEntities = (GenelibSystem.ServerAPI.World.LoadedEntities
+                as CachingConcurrentDictionary<long, Entity>)?.Values;
+            if (loadedEntities != null) {
+                foreach (Entity entity in loadedEntities) {
+                    if (entity.WatchedAttributes.GetLong("motherId", -1) == renamedUID) {
+                        entity.WatchedAttributes.SetString("motherName", newName);
+                    }
+                    if (entity.WatchedAttributes.GetLong("fatherId", -1) == renamedUID) {
+                        entity.WatchedAttributes.SetString("fatherName", newName);
+                    }
+                    if (entity.WatchedAttributes.GetLong("fosterId", -1) == renamedUID) {
+                        entity.WatchedAttributes.SetString("fosterName", newName);
+                    }
+                }
+            }
         }
 
         public static void OnSetNoteMessageServer(IServerPlayer fromPlayer, SetNoteMessage message) {

--- a/src/Entity/Behavior/BehaviorAnimalInfo.cs
+++ b/src/Entity/Behavior/BehaviorAnimalInfo.cs
@@ -57,25 +57,21 @@ namespace Genelib {
                 return;
             }
             string newName = message.name;
-            target.Api.Logger.Audit(fromPlayer.PlayerName + " changed name of " + target.Code + " ID " + target.EntityId + " at " + target.Pos.XYZ.AsBlockPos 
+            target.Api.Logger.Audit(fromPlayer.PlayerName + " changed name of " + target.Code + " ID " + target.EntityId + " at " + target.Pos.XYZ.AsBlockPos
                 + " from " + nametag.DisplayName + " to " + newName);
-	    nametag.SetName(newName);
+            nametag.SetName(newName);
 
-	    // Update stored parent name on all offspring
+            // Update stored parent name on all offspring
             long renamedUID = target.UniqueID();
-            var loadedEntities = (GenelibSystem.ServerAPI.World.LoadedEntities
-                as CachingConcurrentDictionary<long, Entity>)?.Values;
-            if (loadedEntities != null) {
-                foreach (Entity entity in loadedEntities) {
-                    if (entity.WatchedAttributes.GetLong("motherId", -1) == renamedUID) {
-                        entity.WatchedAttributes.SetString("motherName", newName);
-                    }
-                    if (entity.WatchedAttributes.GetLong("fatherId", -1) == renamedUID) {
-                        entity.WatchedAttributes.SetString("fatherName", newName);
-                    }
-                    if (entity.WatchedAttributes.GetLong("fosterId", -1) == renamedUID) {
-                        entity.WatchedAttributes.SetString("fosterName", newName);
-                    }
+            foreach (Entity entity in GenelibSystem.ServerAPI.World.LoadedEntities.Values) {
+                if (entity.WatchedAttributes.GetLong("motherId", -1) == renamedUID) {
+                    entity.WatchedAttributes.SetString("motherName", newName);
+                }
+                if (entity.WatchedAttributes.GetLong("fatherId", -1) == renamedUID) {
+                    entity.WatchedAttributes.SetString("fatherName", newName);
+                }
+                if (entity.WatchedAttributes.GetLong("fosterId", -1) == renamedUID) {
+                    entity.WatchedAttributes.SetString("fosterName", newName);
                 }
             }
         }


### PR DESCRIPTION
If you rename an animal, the children don't reflect the rename in their info tab. This should fix that.